### PR TITLE
fix autocompletion 

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -1,3 +1,14 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+	. /etc/bashrc
+fi
+
+# Uncomment the following line if you don't like systemctl's auto-paging feature:
+# export SYSTEMD_PAGER=
+
+# User specific aliases and functions
 # ~/.bashrc: executed by bash(1) for non-login shells.
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples


### PR DESCRIPTION
in Fedora 22, out of the box, you need to source `/etc/bashrc` for this to work. It's sort of good practice to do it anyway, especially when you later source `/etc/bash_completion` :).